### PR TITLE
MYO-5584 - added converter html text to plain text in ios18

### DIFF
--- a/WrapKitCore/Sources/WrapKitCommon/Helpers/String+Extensions.swift
+++ b/WrapKitCore/Sources/WrapKitCommon/Helpers/String+Extensions.swift
@@ -36,14 +36,26 @@ public extension String {
     var asHtmlAttributedString: NSAttributedString? {
         guard let data = data(using: .utf8) else { return nil }
                 
-        return try? NSAttributedString(
-            data: data,
-            options: [
-                .documentType: NSAttributedString.DocumentType.html,
-                .characterEncoding: String.Encoding.utf8.rawValue
-            ],
-            documentAttributes: nil
-        )
+        if #available(macOS 15.0, iOS 18.0, *) {
+            return try? NSAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue,
+                    .textKit1ListMarkerFormatDocumentOption: true
+                ],
+                documentAttributes: nil
+            )
+        } else {
+            return try? NSAttributedString(
+                data: data,
+                options: [
+                    .documentType: NSAttributedString.DocumentType.html,
+                    .characterEncoding: String.Encoding.utf8.rawValue
+                ],
+                documentAttributes: nil
+            )
+        }
     }
     
     func asDate(withFormat format: String) -> Date? {


### PR DESCRIPTION
Jira:
- Исправить конвертер html текста на ios 18
- https://jira.o.kg/browse/MYO-5584

На iOS 18 действительно поменялось поведение HTML-парсера для NSAttributedString:

Ограниченная поддержка CSS
Парсер по прежнему умеет «прочитать» только встроенные стили (inline-style) в теге, но не обрабатывает внешние <style>-блоки или большинство CSS-правил. Всё, что вы пишете в <style>…</style> в <head>, просто отбрасывается; работают лишь атрибуты вида <span style="color:red; font-weight:bold">…</span> 
[cocoanetics.com](https://www.cocoanetics.com/2011/08/nsattributedstringhtml-qa/?utm_source=chatgpt.com)
.

Списки и маркеры в TextKit 1
До iOS 18 TextKit 1 (тот, что лежит в основе UILabel и старых UITextView) при конвертации HTML в атрибутированную строку автоматически вставлял номера/буллеты прямо в текст. В iOS 18 эту «фичу» убрали — маркеры из текста пропадают.
Чтобы вернуть их, Apple добавила новый ключ чтения:

swift
Копировать
let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
  .documentType: .html,
  .characterEncoding: String.Encoding.utf8.rawValue,
  .textKit1ListMarkerFormatDocumentOption: true  // ← именно для TextKit 1 на iOS 18+
]
let attr = try? NSAttributedString(data: Data(html.utf8), options: options, documentAttributes: nil)
Это ключ стал доступен лишь начиная с iOS 18